### PR TITLE
Sets max on automated navigation items

### DIFF
--- a/templates/snippets/header/menu.liquid
+++ b/templates/snippets/header/menu.liquid
@@ -22,6 +22,7 @@
       {%- render "header/submenu", category: category %}
     </li>
   {%- endif %}
+  {%- if forloop.index == 7 %}{% break %}{%- endif %}
 {%- endfor %}
 
 <li class="SC-Menu_item tier1">


### PR DESCRIPTION
# Motivation 

If a user does not set a custom menu for the store, the theme automatically assigns header/menu and populates it with the store's current store's categories. However, when the menu exceeds 6-7 items, it causes an overflow, breaking the header layout.

## Solution

Break the automated items when they have reached 7 items in total.