### PR TITLE
release/v21

### DIFF
--- a/components/cart-menu.liquid
+++ b/components/cart-menu.liquid
@@ -1,3 +1,5 @@
+{%- require "scripts/nav.js" -%}
+
 {%- capture item_count %}
   {%- if current_cart != blank and current_cart.item_count > 0 %}
     <div class="SC-Count sc-ml-tiny" data-cart-nav-count>

--- a/templates/layouts/theme.liquid
+++ b/templates/layouts/theme.liquid
@@ -21,6 +21,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ csrf_meta_tags }}
     {{ csp_meta_tag }}
+    {%- render "content_security_policy_header" %}
     {%- render "meta_data", title: title, meta_keywords: meta_keywords, meta_description: meta_description %}
 
     {%- comment -%} Styles {%- endcomment -%}

--- a/templates/pages/cart.liquid
+++ b/templates/pages/cart.liquid
@@ -3,9 +3,9 @@
     {%- render "shared/page_header", heading: "t.cart.header" %}
 
     <div data-cart-page-cart>
-      {%- render "cart/cart" %}
+      {%- component "cart", reload: "sc.cart-updated" %}
     </div>
-  
+
     {%- if current_cart.items.size > 0 %}
       {% assign upsell_products = all_product_categories['all'].products %}
       {%- render 'shared/upsell_products', upsell_products: upsell_products %}

--- a/templates/snippets/header.liquid
+++ b/templates/snippets/header.liquid
@@ -15,7 +15,7 @@
       {%- endif %}
     </a>
     {%- endcapture %}
-    
+
     {%- assign menu_identifier = current_store.header_menu | try: "identifier" | default: "header" %}
 
     <header class="SC-Header" id="SC-Header">
@@ -23,9 +23,9 @@
       <div class="SC-Header_inner">
 
         <div class="SC-Header_inner_left">
-          <button 
-            data-menu-init="{{ menu_identifier }}" 
-            class="SC-Icon SC-Icon-button SC-Icon-large sc-hide-large-and-up" 
+          <button
+            data-menu-init="{{ menu_identifier }}"
+            class="SC-Icon SC-Icon-button SC-Icon-large sc-hide-large-and-up"
             type="button">
             {%- render "shared/icons/hamburger" %}
           </button>
@@ -53,7 +53,7 @@
           <ul class="SC-Menu tier1 end sc-justify-end" id="SC-HeaderMenuSecondary">
             {%- render "header/dropdown/search" %}
             {%- render "header/dropdown/account" %}
-            {%- render "header/dropdown/cart" %}
+            {%- component "cart-menu", reload: "sc.cart-updated sc.voucher-applied sc.voucher-removed" %}
           </ul>
         </div>
       </div>

--- a/templates/snippets/products/card.liquid
+++ b/templates/snippets/products/card.liquid
@@ -74,6 +74,10 @@
           <span class="SC-ProductCard_price_item">
             {{ product.pricing.hide_price_text }}
           </span>
+        {%- elsif product.bundle_anchor? %}
++         <span class="SC-ProductCard_price_item">
++           {{ product.initial_bundle_total | money }}
++         </span>
         {%- elsif product.pricing.has_price? %}
 
           {%- comment %} Currency Price {% endcomment %}

--- a/templates/snippets/shared/cart_items/item.liquid
+++ b/templates/snippets/shared/cart_items/item.liquid
@@ -44,10 +44,11 @@
         {%- endif %}
         {%- comment %} Bundles {% endcomment %}
         {%- if cart_item.in_bundle? %}
-          {%- if extended %}
-          <a href="{{ cart_item.edit_bundle_path }}" class="SC-Link sc-font-small">
-            {{ "cart_items.links.edit_bundle" | t }}
-          </a>
+          {%- comment %} Only show Edit Bundle link if bundle doesn't have bookable components {% endcomment %}
+          {%- if extended and cart_item.bundle_has_bookable_components? == false and cart_item.has_nested_bundle_items? == false %}
+            <a href="{{ cart_item.edit_bundle_path }}" class="SC-Link sc-font-small">
+              {{ "cart_items.links.edit_bundle" | t }}
+            </a>
           {%- endif %}
           <em class="sc-display-block sc-font-small sc-shade-dark">
             {{ "bundles.bundle.includes" | t }}
@@ -55,12 +56,43 @@
           <ul class="sc-m-none sc-pl-base sc-font-tiny sc-shade-dark">
             {%- assign quantity_of_bundles = cart_item.quantity %}
             {%- for bundle_item in cart_item.bundle_items %}
-              {%- unless bundle_item.bundle_lead? %}
+              {%- comment %} Skip the bundle lead itself {% endcomment %}
+              {%- if bundle_item.bundle_lead? %}
+                {%- continue %}
+              {%- endif %}
+
+              {%- comment %} Check if this item is a nested bundle (bundle_anchor with its own children) {% endcomment %}
+              {%- assign is_nested_bundle = false %}
+              {%- if bundle_item.product.bundle_anchor? %}
+                {%- assign is_nested_bundle = true %}
+              {%- endif %}
+
+              {%- if is_nested_bundle %}
                 <li>
                   {{ bundle_item.quantity | divided_by: quantity_of_bundles }}
                   {{ bundle_item.product.name }}
+                  {%- comment %} Show nested bundle's components {% endcomment %}
+                  <ul class="sc-m-none sc-pl-base sc-font-tiny sc-shade-dark sc-mt-micro">
+                    {%- for nested_item in bundle_item.bundle_items %}
+                      <li>
+                        {{ nested_item.quantity | divided_by: quantity_of_bundles }}
+                        {{ nested_item.product.name }}
+                      </li>
+                    {%- endfor %}
+                  </ul>
                 </li>
-              {%- endunless %}
+              {%- else %}
+                <li>
+                  {{ bundle_item.quantity | divided_by: quantity_of_bundles }}
+                  {{ bundle_item.product.name }}
+                  {%- comment %} Show booking details for bookable components {% endcomment %}
+                  {%- if bundle_item.product.bookable? and bundle_item.bookable_event != blank %}
+                    <div class="sc-mt-micro sc-shade-neutral">
+                      {%- render "shared/cart_items/booking_details", bookable_event: bundle_item.bookable_event, extended: false %}
+                    </div>
+                  {%- endif %}
+                </li>
+              {%- endif %}
             {%- endfor %}
           </ul>
         {%- endif %}
@@ -113,6 +145,18 @@
       {%- comment %} Total {% endcomment %}
       <div class="sc-expand sc-text-right" data-line-item-pricing="{{ cart_item.id }}" data-product-id="{{ cart_item.product.id }}">
         {%- render "shared/cart_items/pricing", pricing: cart_item.pricing, compact: compact %}
+
+        {%- comment %} Remaining Deposit (order items only) {% endcomment %}
+        {%- assign amount_paid = cart_item.amount_paid | default: 0 %}
+        {%- if amount_paid > 0 and cart_item.deposit_required? %}
+          {%- assign remaining_deposit = cart_item.deposit_amount | minus: amount_paid %}
+          {%- if remaining_deposit > 0 %}
+            {%- assign remaining_deposit_formatted = remaining_deposit | money %}
+            <div class="sc-shade-neutral sc-font-tiny sc-mt-tiny" data-line-item-remaining-deposit>
+              {{ "pricing.remaining_deposit" | t: amount: remaining_deposit_formatted }}
+            </div>
+          {%- endif %}
+        {%- endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Converted the cart dropdown from a header snippet to a reusable component (components/cart-menu.liquid) with reactive reload support for cart and voucher events (sc.cart-updated, sc.voucher-applied, sc.voucher-removed)
- Updated the cart page to use the component render pattern (component "cart") with reactive reload on sc.cart-updated
- Added bundle anchor product pricing display on product cards, showing initial_bundle_total for bundle anchor products
- Improved cart item bundle rendering: suppressed the "Edit Bundle" link for bundles with bookable or nested bundle components, added nested bundle item display with their own sub-components, and added booking details for bookable bundle components
- Added remaining deposit display to cart items for order items with outstanding deposits
- Added content_security_policy_header render to the theme layout and bumped theme version to v21